### PR TITLE
Add opit.com domain for OPIT – Open Institute of Technology

### DIFF
--- a/lib/domains/com/OPIT.txt
+++ b/lib/domains/com/OPIT.txt
@@ -1,0 +1,1 @@
+OPIT - Open Institute of Technology


### PR DESCRIPTION
Institution name:
OPIT – Open Institute of Technology

Official website:
https://www.opit.com

Official long-term IT-related courses (1+ year):
- https://www.opit.com/bachelor-of-science-in-computer-science/
- https://www.opit.com/master-of-science-in-applied-data-science-and-ai/

Email domain for students:
Students receive official email addresses in the format @students.opit.com.

Domain to be added:
opit.com

File path to add:
lib/domains/com/opit.txt

File contents:
OPIT – Open Institute of Technology